### PR TITLE
初回は CMAKE_BUILD_TYPE をセットしていないとエラーになる

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -15,7 +15,7 @@ brew install cmake
 
 ```
 cd your_clone_dir/src
-cmake -D BONE_RUN=1 .
+cmake -D CMAKE_BUILD_TYPE=Debug -D BONE_RUN=1 .
 make
 ```
 


### PR DESCRIPTION
初回は CMAKE_BUILD_TYPE が無いのでエラーになります。

```
% cmake -D BONE_RUN=1 .
-- The C compiler identification is AppleClang 11.0.0.11000033
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Found PkgConfig: /usr/local/bin/pkg-config (found version "0.29.2") 
-- Checking for module 'glib-2.0'
--   Found glib-2.0, version 2.62.0
CMake Error at CMakeLists.txt:60 (message):
  please fix build type:

```

https://qiita.com/janus_wel/items/a673793d448c72cbc95e#モード指定
> 一度でも他の値で書き換えるとずっと記憶する
